### PR TITLE
fix: remove old mongoose options

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2,19 +2,9 @@ import mongoose from 'mongoose';
 
 import { config } from './config';
 
-export const connectDatabase = () => {
-  return new Promise((resolve, reject) => {
-    mongoose.Promise = global.Promise;
-    mongoose.connection
-      .on('error', error => reject(error))
-      // eslint-disable-next-line
-      .on('close', () => console.log('Database connection closed.'))
-      .once('open', () => resolve(mongoose.connections[0]));
+export const connectDatabase = async (): Promise<void> => {
+  // eslint-disable-next-line no-console
+  mongoose.connection.on('close', () => console.log('Database connection closed.'));
 
-    mongoose.connect(config.MONGO_URI, {
-      useNewUrlParser: true,
-      useCreateIndex: true,
-      useUnifiedTopology: true,
-    });
-  });
+  await mongoose.connect(config.MONGO_URI);
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
```
[1] (node:3336) UnhandledPromiseRejectionWarning: MongoParseError: option usecreateindex is not supported
```
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
