### PR TITLE
Fix MUI direct imports

### DIFF
--- a/packages/ui/src/BackButton.tsx
+++ b/packages/ui/src/BackButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import ArrowBackIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import IconButton from '@mui/material/IconButton';
 
 import { useHistory } from '@workshop/route';
 

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { flexbox, FlexboxProps, space, SpaceProps } from 'styled-system';
-import _Button from '@mui/material';
+import _Button from '@mui/material/Button';
 
 interface ButtonProps extends FlexboxProps, SpaceProps {}
 

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import _Card from '@mui/material';
+import _Card from '@mui/material/Card';
 import { flexbox, space, layout, FlexboxProps, SpaceProps, compose, LayoutProps } from 'styled-system';
 
 interface CardProps extends FlexboxProps, SpaceProps, LayoutProps {}

--- a/packages/ui/src/CardActions.tsx
+++ b/packages/ui/src/CardActions.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import _CardActions from '@mui/material';
+import _CardActions from '@mui/material/CardActions';
 import { flexbox, FlexboxProps, space, SpaceProps } from 'styled-system';
 
 interface CardActionsProps extends FlexboxProps, SpaceProps {}

--- a/packages/ui/src/TextArea.tsx
+++ b/packages/ui/src/TextArea.tsx
@@ -1,4 +1,4 @@
-import TextField from '@mui/material';
+import TextField from '@mui/material/TextField';
 import styled from 'styled-components';
 
 export const TextArea = styled(TextField).attrs({

--- a/packages/ui/src/TextField.tsx
+++ b/packages/ui/src/TextField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useField } from 'formik';
-import _TextFieldMaterial from '@mui/material';
-import MaterialUITextFieldProps from '@mui/material/TextFieldProps';
+import _TextFieldMaterial from '@mui/material/TextField';
+import MaterialUITextFieldProps from '@mui/material/TextField/TextFieldProps';
 import styled from 'styled-components';
 import { flexbox, FlexboxProps, space, SpaceProps } from 'styled-system';
 

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -1,4 +1,4 @@
-import createMuiTheme from '@mui/material/createMuiTheme';
+import createMuiTheme from '@mui/material/styles/createMuiTheme';
 
 // TODO - customize material ui theme
 export const theme = {

--- a/packages/web/src/components/auth/AuthRoot.tsx
+++ b/packages/web/src/components/auth/AuthRoot.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
-import AppBar from '@mui/material';
-import Toolbar from '@mui/material';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
 import { Text } from 'rebass';
 
 const AuthRoot = ({ children }) => {

--- a/packages/web/src/components/feed/FeedList.tsx
+++ b/packages/web/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/packages/web/src/components/feed/PostComposer.tsx
+++ b/packages/web/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/packages/web/src/components/feed/Root.tsx
+++ b/packages/web/src/components/feed/Root.tsx
@@ -1,10 +1,10 @@
 import React, { Suspense } from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
-import AppBar from '@mui/material';
-import Toolbar from '@mui/material';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
 import { Text } from 'rebass';
-import ExitToAppIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import ExitToAppIcon from '@mui/icons-material/ExitToApp';
+import IconButton from '@mui/material/IconButton';
 
 import { usePreloadedQuery } from 'react-relay';
 

--- a/packages/web/src/components/feed/UserAvatar.tsx
+++ b/packages/web/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/packages/web/src/components/feed/comment/PostCommentComposer.tsx
+++ b/packages/web/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from 'react-relay';
 

--- a/packages/web/src/components/feed/comment/PostComments.tsx
+++ b/packages/web/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/packages/web/src/components/feed/like/PostLikeButton.tsx
+++ b/packages/web/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/packages/web/src/components/feed/post/Post.tsx
+++ b/packages/web/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/packages/web/src/components/feed/useNewPostSubscription.tsx
+++ b/packages/web/src/components/feed/useNewPostSubscription.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import Button from '@mui/material';
+import Button from '@mui/material/Button';
 
 import { useSnackbar } from 'notistack';
 

--- a/packages/web/src/components/ui/BackButton.tsx
+++ b/packages/web/src/components/ui/BackButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import ArrowBackIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import IconButton from '@mui/material/IconButton';
 
 import { useHistory } from '@workshop/route';
 

--- a/solutions/05-useMutation/src/Post.tsx
+++ b/solutions/05-useMutation/src/Post.tsx
@@ -2,9 +2,9 @@ import React, { useCallback } from 'react';
 import { useFragment, graphql } from 'react-relay';
 import { Text } from 'rebass';
 import { Card, CardActions, theme } from '@workshop/ui';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import IconButton from '@mui/material/IconButton';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/06-mutationUpdater/src/comment/PostCommentComposer.tsx
+++ b/solutions/06-mutationUpdater/src/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/06-mutationUpdater/src/comment/UserAvatar.tsx
+++ b/solutions/06-mutationUpdater/src/comment/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/06-mutationUpdater/src/like/PostLikeButton.tsx
+++ b/solutions/06-mutationUpdater/src/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/solutions/07-useRefetchableFragment/src/comment/PostCommentComposer.tsx
+++ b/solutions/07-useRefetchableFragment/src/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/07-useRefetchableFragment/src/comment/PostComments.tsx
+++ b/solutions/07-useRefetchableFragment/src/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/07-useRefetchableFragment/src/comment/UserAvatar.tsx
+++ b/solutions/07-useRefetchableFragment/src/comment/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/07-useRefetchableFragment/src/like/PostLikeButton.tsx
+++ b/solutions/07-useRefetchableFragment/src/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/solutions/08-useSubscription/src/comment/PostCommentComposer.tsx
+++ b/solutions/08-useSubscription/src/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/08-useSubscription/src/comment/PostComments.tsx
+++ b/solutions/08-useSubscription/src/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/08-useSubscription/src/comment/UserAvatar.tsx
+++ b/solutions/08-useSubscription/src/comment/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/08-useSubscription/src/like/PostLikeButton.tsx
+++ b/solutions/08-useSubscription/src/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/solutions/08-useSubscription/src/postSubscription/useNewPostSubscription.tsx
+++ b/solutions/08-useSubscription/src/postSubscription/useNewPostSubscription.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import Button from '@mui/material';
+import Button from '@mui/material/Button';
 
 import { useSnackbar } from 'notistack';
 

--- a/solutions/09-usePreloadedQuery/src/components/feed/FeedList.tsx
+++ b/solutions/09-usePreloadedQuery/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/solutions/09-usePreloadedQuery/src/components/feed/PostComposer.tsx
+++ b/solutions/09-usePreloadedQuery/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/solutions/09-usePreloadedQuery/src/components/feed/UserAvatar.tsx
+++ b/solutions/09-usePreloadedQuery/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/09-usePreloadedQuery/src/components/feed/comment/PostCommentComposer.tsx
+++ b/solutions/09-usePreloadedQuery/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/09-usePreloadedQuery/src/components/feed/comment/PostComments.tsx
+++ b/solutions/09-usePreloadedQuery/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/09-usePreloadedQuery/src/components/feed/like/PostLikeButton.tsx
+++ b/solutions/09-usePreloadedQuery/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/solutions/09-usePreloadedQuery/src/components/feed/post/Post.tsx
+++ b/solutions/09-usePreloadedQuery/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/solutions/10-testUsePreloadQuery/src/components/feed/FeedList.tsx
+++ b/solutions/10-testUsePreloadQuery/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/solutions/10-testUsePreloadQuery/src/components/feed/PostComposer.tsx
+++ b/solutions/10-testUsePreloadQuery/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/solutions/10-testUsePreloadQuery/src/components/feed/UserAvatar.tsx
+++ b/solutions/10-testUsePreloadQuery/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/10-testUsePreloadQuery/src/components/feed/comment/PostCommentComposer.tsx
+++ b/solutions/10-testUsePreloadQuery/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/10-testUsePreloadQuery/src/components/feed/comment/PostComments.tsx
+++ b/solutions/10-testUsePreloadQuery/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/10-testUsePreloadQuery/src/components/feed/like/PostLikeButton.tsx
+++ b/solutions/10-testUsePreloadQuery/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/solutions/10-testUsePreloadQuery/src/components/feed/post/Post.tsx
+++ b/solutions/10-testUsePreloadQuery/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/solutions/11-testUseFragment/src/components/feed/FeedList.tsx
+++ b/solutions/11-testUseFragment/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/solutions/11-testUseFragment/src/components/feed/PostComposer.tsx
+++ b/solutions/11-testUseFragment/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/solutions/11-testUseFragment/src/components/feed/UserAvatar.tsx
+++ b/solutions/11-testUseFragment/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/11-testUseFragment/src/components/feed/comment/PostCommentComposer.tsx
+++ b/solutions/11-testUseFragment/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/11-testUseFragment/src/components/feed/comment/PostComments.tsx
+++ b/solutions/11-testUseFragment/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/11-testUseFragment/src/components/feed/like/PostLikeButton.tsx
+++ b/solutions/11-testUseFragment/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/solutions/11-testUseFragment/src/components/feed/post/Post.tsx
+++ b/solutions/11-testUseFragment/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/solutions/12-testUseMutation/src/components/feed/FeedList.tsx
+++ b/solutions/12-testUseMutation/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/solutions/12-testUseMutation/src/components/feed/PostComposer.tsx
+++ b/solutions/12-testUseMutation/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/solutions/12-testUseMutation/src/components/feed/UserAvatar.tsx
+++ b/solutions/12-testUseMutation/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/12-testUseMutation/src/components/feed/comment/PostCommentComposer.tsx
+++ b/solutions/12-testUseMutation/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/solutions/12-testUseMutation/src/components/feed/comment/PostComments.tsx
+++ b/solutions/12-testUseMutation/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/solutions/12-testUseMutation/src/components/feed/like/PostLikeButton.tsx
+++ b/solutions/12-testUseMutation/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/solutions/12-testUseMutation/src/components/feed/post/Post.tsx
+++ b/solutions/12-testUseMutation/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/workshop/05-useMutation/src/Post.tsx
+++ b/workshop/05-useMutation/src/Post.tsx
@@ -2,9 +2,9 @@ import React, { useCallback } from 'react';
 import { useFragment, graphql } from 'react-relay';
 import { Text } from 'rebass';
 import { Card, CardActions, theme } from '@workshop/ui';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import IconButton from '@mui/material/IconButton';
 
 import { Post_post, Post_post$key } from './__generated__/Post_post.graphql';
 

--- a/workshop/06-mutationUpdater/src/comment/PostCommentComposer.tsx
+++ b/workshop/06-mutationUpdater/src/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/workshop/06-mutationUpdater/src/comment/UserAvatar.tsx
+++ b/workshop/06-mutationUpdater/src/comment/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/06-mutationUpdater/src/like/PostLikeButton.tsx
+++ b/workshop/06-mutationUpdater/src/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/workshop/07-useRefetchableFragment/src/comment/PostCommentComposer.tsx
+++ b/workshop/07-useRefetchableFragment/src/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/workshop/07-useRefetchableFragment/src/comment/PostComments.tsx
+++ b/workshop/07-useRefetchableFragment/src/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/07-useRefetchableFragment/src/comment/UserAvatar.tsx
+++ b/workshop/07-useRefetchableFragment/src/comment/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/07-useRefetchableFragment/src/like/PostLikeButton.tsx
+++ b/workshop/07-useRefetchableFragment/src/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/workshop/08-useSubscription/src/comment/PostCommentComposer.tsx
+++ b/workshop/08-useSubscription/src/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/workshop/08-useSubscription/src/comment/PostComments.tsx
+++ b/workshop/08-useSubscription/src/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/08-useSubscription/src/comment/UserAvatar.tsx
+++ b/workshop/08-useSubscription/src/comment/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/08-useSubscription/src/like/PostLikeButton.tsx
+++ b/workshop/08-useSubscription/src/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/workshop/08-useSubscription/src/postSubscription/useNewPostSubscription.tsx
+++ b/workshop/08-useSubscription/src/postSubscription/useNewPostSubscription.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
 import React, { useMemo } from 'react';
-import Button from '@mui/material';
+import Button from '@mui/material/Button';
 
 import { useSnackbar } from 'notistack';
 

--- a/workshop/09-usePreloadedQuery/src/components/feed/FeedList.tsx
+++ b/workshop/09-usePreloadedQuery/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/workshop/09-usePreloadedQuery/src/components/feed/PostComposer.tsx
+++ b/workshop/09-usePreloadedQuery/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/workshop/09-usePreloadedQuery/src/components/feed/UserAvatar.tsx
+++ b/workshop/09-usePreloadedQuery/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/09-usePreloadedQuery/src/components/feed/comment/PostCommentComposer.tsx
+++ b/workshop/09-usePreloadedQuery/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/workshop/09-usePreloadedQuery/src/components/feed/comment/PostComments.tsx
+++ b/workshop/09-usePreloadedQuery/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/09-usePreloadedQuery/src/components/feed/like/PostLikeButton.tsx
+++ b/workshop/09-usePreloadedQuery/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/workshop/09-usePreloadedQuery/src/components/feed/post/Post.tsx
+++ b/workshop/09-usePreloadedQuery/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/workshop/10-testUsePreloadQuery/src/components/feed/FeedList.tsx
+++ b/workshop/10-testUsePreloadQuery/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/workshop/10-testUsePreloadQuery/src/components/feed/PostComposer.tsx
+++ b/workshop/10-testUsePreloadQuery/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/workshop/10-testUsePreloadQuery/src/components/feed/UserAvatar.tsx
+++ b/workshop/10-testUsePreloadQuery/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/10-testUsePreloadQuery/src/components/feed/comment/PostCommentComposer.tsx
+++ b/workshop/10-testUsePreloadQuery/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/workshop/10-testUsePreloadQuery/src/components/feed/comment/PostComments.tsx
+++ b/workshop/10-testUsePreloadQuery/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/10-testUsePreloadQuery/src/components/feed/like/PostLikeButton.tsx
+++ b/workshop/10-testUsePreloadQuery/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/workshop/10-testUsePreloadQuery/src/components/feed/post/Post.tsx
+++ b/workshop/10-testUsePreloadQuery/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/workshop/11-testUseFragment/src/components/feed/FeedList.tsx
+++ b/workshop/11-testUseFragment/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/workshop/11-testUseFragment/src/components/feed/PostComposer.tsx
+++ b/workshop/11-testUseFragment/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/workshop/11-testUseFragment/src/components/feed/UserAvatar.tsx
+++ b/workshop/11-testUseFragment/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/11-testUseFragment/src/components/feed/comment/PostCommentComposer.tsx
+++ b/workshop/11-testUseFragment/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/workshop/11-testUseFragment/src/components/feed/comment/PostComments.tsx
+++ b/workshop/11-testUseFragment/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/11-testUseFragment/src/components/feed/like/PostLikeButton.tsx
+++ b/workshop/11-testUseFragment/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/workshop/11-testUseFragment/src/components/feed/post/Post.tsx
+++ b/workshop/11-testUseFragment/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';

--- a/workshop/12-testUseMutation/src/components/feed/FeedList.tsx
+++ b/workshop/12-testUseMutation/src/components/feed/FeedList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePaginationFragment, graphql } from 'react-relay/lib/hooks';
 
 import InfiniteScroll from 'react-infinite-scroller';
-import CircularProgress from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { Flex } from 'rebass';
 
 import Post from './post/Post';

--- a/workshop/12-testUseMutation/src/components/feed/PostComposer.tsx
+++ b/workshop/12-testUseMutation/src/components/feed/PostComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import CardContent from '@mui/material';
-import Button from '@mui/material';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
 
 import { Card, TextArea, CardActions } from '@workshop/ui';
 

--- a/workshop/12-testUseMutation/src/components/feed/UserAvatar.tsx
+++ b/workshop/12-testUseMutation/src/components/feed/UserAvatar.tsx
@@ -4,7 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 
 import { Text, Flex } from 'rebass';
-import Avatar from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/12-testUseMutation/src/components/feed/comment/PostCommentComposer.tsx
+++ b/workshop/12-testUseMutation/src/components/feed/comment/PostCommentComposer.tsx
@@ -3,11 +3,11 @@ import { useFragment } from 'react-relay';
 
 import { Flex } from 'rebass';
 
-import SendIcon from '@mui/icons-material';
-import IconButton from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import IconButton from '@mui/material/IconButton';
 import { graphql } from 'react-relay';
 
-import Divider from '@mui/material';
+import Divider from '@mui/material/Divider';
 
 import { useMutation } from '@workshop/relay';
 

--- a/workshop/12-testUseMutation/src/components/feed/comment/PostComments.tsx
+++ b/workshop/12-testUseMutation/src/components/feed/comment/PostComments.tsx
@@ -1,8 +1,8 @@
 import React, { unstable_useTransition as useTransition } from 'react';
 import { graphql, useRefetchableFragment } from 'react-relay';
 import { Flex, Text } from 'rebass';
-import Button from '@mui/material';
-import CircularProgress from '@mui/material';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 
 import { theme } from '@workshop/ui';
 

--- a/workshop/12-testUseMutation/src/components/feed/like/PostLikeButton.tsx
+++ b/workshop/12-testUseMutation/src/components/feed/like/PostLikeButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import FavoriteIcon from '@mui/icons-material';
-import FavoriteBorderIcon from '@mui/icons-material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 
 import { useFragment } from 'react-relay';
-import IconButton from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 
 import { graphql } from 'react-relay';
 

--- a/workshop/12-testUseMutation/src/components/feed/post/Post.tsx
+++ b/workshop/12-testUseMutation/src/components/feed/post/Post.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CardContent from '@mui/material';
+import CardContent from '@mui/material/CardContent';
 import { useFragment } from 'react-relay';
 import { graphql } from 'react-relay';
 import styled from 'styled-components';


### PR DESCRIPTION
# Summary

Fix direct imports. In the last PR, my [codemod](https://gist.github.com/fersilva16/19d1f09cc448858c500d926feda92ea4) was an error that removes the path suffix, for example: `@material-ui/core/Button` to `@mui/material`. Now it's fixed.