### PR TITLE
Replace imports on `webpack.config.js` in solutions/ and workshop.

### DIFF
--- a/solutions/01-fetchGraphql/webpack.config.js
+++ b/solutions/01-fetchGraphql/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/02-useLazyLoadQuery/webpack.config.js
+++ b/solutions/02-useLazyLoadQuery/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/03-useFragment/webpack.config.js
+++ b/solutions/03-useFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/04-usePaginationFragment/webpack.config.js
+++ b/solutions/04-usePaginationFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/05-useMutation/webpack.config.js
+++ b/solutions/05-useMutation/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/06-mutationUpdater/webpack.config.js
+++ b/solutions/06-mutationUpdater/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/07-useRefetchableFragment/webpack.config.js
+++ b/solutions/07-useRefetchableFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/08-useSubscription/webpack.config.js
+++ b/solutions/08-useSubscription/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/09-usePreloadedQuery/webpack.config.js
+++ b/solutions/09-usePreloadedQuery/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/10-testUsePreloadQuery/webpack.config.js
+++ b/solutions/10-testUsePreloadQuery/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/11-testUseFragment/webpack.config.js
+++ b/solutions/11-testUseFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/solutions/12-testUseMutation/webpack.config.js
+++ b/solutions/12-testUseMutation/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/01-fetchGraphql/webpack.config.js
+++ b/workshop/01-fetchGraphql/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/02-useLazyLoadQuery/webpack.config.js
+++ b/workshop/02-useLazyLoadQuery/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/03-useFragment/webpack.config.js
+++ b/workshop/03-useFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/04-usePaginationFragment/webpack.config.js
+++ b/workshop/04-usePaginationFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/05-useMutation/webpack.config.js
+++ b/workshop/05-useMutation/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/06-mutationUpdater/webpack.config.js
+++ b/workshop/06-mutationUpdater/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/07-useRefetchableFragment/webpack.config.js
+++ b/workshop/07-useRefetchableFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/08-useSubscription/webpack.config.js
+++ b/workshop/08-useSubscription/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/09-usePreloadedQuery/webpack.config.js
+++ b/workshop/09-usePreloadedQuery/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/10-testUsePreloadQuery/webpack.config.js
+++ b/workshop/10-testUsePreloadQuery/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/11-testUseFragment/webpack.config.js
+++ b/workshop/11-testUseFragment/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;

--- a/workshop/12-testUseMutation/webpack.config.js
+++ b/workshop/12-testUseMutation/webpack.config.js
@@ -1,3 +1,3 @@
-const webpackConfig = require('@workshop/webpack');
+const { webpackDevConfig } = require('@workshop/webpack');
 
-module.exports = webpackConfig;
+module.exports = webpackDevConfig;


### PR DESCRIPTION
# Summary

Here we fix the import of `webpackDevConfig` on webpack config file in the projects inside `solutions/` and `workshop/` folders.

Close #962 