### PR TITLE
fix(webpack): add zlib fallback

### DIFF
--- a/packages/webpack/src/webpack.config.js
+++ b/packages/webpack/src/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const dotEnv = require('dotenv-webpack');
-const webpack = require('webpack')
+const webpack = require('webpack');
 
 const cwd = process.cwd();
 const outputPath = path.join(cwd, 'build');
@@ -24,8 +24,11 @@ module.exports = {
       http: require.resolve('stream-http'),
       https: require.resolve('https-browserify'),
       os: require.resolve('os-browserify/browser'),
-      "crypto": require.resolve("crypto-browserify"),
-      "stream": require.resolve("stream-browserify"),
+      crypto: require.resolve('crypto-browserify'),
+      stream: require.resolve('stream-browserify'),
+      zlib: require.resolve('browserify-zlib'),
+      assert: require.resolve('assert/'),
+      buffer: require.resolve('buffer/'),
     },
   },
   module: {
@@ -62,6 +65,6 @@ module.exports = {
     }),
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],
-    })
+    }),
   ],
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

#### What issues does the pull request solve?
Issue #2696.
#### How did you implement the solution?
Add fallbacks to webpack config (zlib, assert and buffer).

### What's required for testing (prerequisites)?

1. Use Node >= v16.14.0
2. Run the `npm start` script inside `workshop/01-fetchGraphql` folder.
